### PR TITLE
Add server API

### DIFF
--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,3 @@
+
+# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
+.specstory/**

--- a/.specstory/.gitignore
+++ b/.specstory/.gitignore
@@ -1,0 +1,2 @@
+# SpecStory explanation file
+/.what-is-this.md

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a simple Express server for task searching and configured SpecStory integration.

### What changed?

- Created a new Express server in `graphite-demo/server.js` that provides a `/search` endpoint for filtering tasks
- Added `.cursorindexingignore` to prevent indexing of SpecStory auto-save files
- Added `.specstory/.gitignore` to exclude SpecStory explanation file from version control

### How to test?

1. Install dependencies: `npm install express`
2. Start the server: `node graphite-demo/server.js`
3. Test the search endpoint: `curl "http://localhost:3000/search?query=report"`
4. Verify that tasks are filtered based on the search query

### Why make this change?

This change introduces a basic task search API that will serve as a foundation for the Graphite demo application. The server provides a simple endpoint to filter tasks based on a search query, which will be used by the frontend to display relevant tasks to users. The SpecStory configuration ensures proper integration with development tools.